### PR TITLE
Fix switch pipenv to sync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: install dependencies
           command: |
             pip install pipenv
-            pipenv install --dev
+            pipenv sync --dev
 
       - save_cache:
           paths:
@@ -83,7 +83,7 @@ jobs:
           command: |
             echo $TRUFFLEHOG_SINCE_COMMIT >> .env
             pip install pipenv
-            pipenv install --dev
+            pipenv sync --dev
 
       - save_cache:
           paths:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -30,7 +30,7 @@ github:
 # List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/44_config_start_tasks/
 tasks:
   - before: git config --global user.email $GIT_COMMITTER_EMAIL
-    init: pipenv install --dev && pipenv run jupyter lab build
+    init: pipenv sync --dev && pipenv run jupyter lab build
     # Note: don't use pipenv shell in prebuild. Since it never ends, neither does prebuild
     prebuild: pipenv run echo "prebuild script ran"
     # Note: if starting the pipenv shell, it must be the last command in the script


### PR DESCRIPTION
Was using `pipenv install --dev` but for regression.  In the outgoing regression, the goal is to test the exact checking in to `Pipfile.lock`, not the latest version.  Therefore, should be switched to `pipenv sync --dev`.

<a href="https://gitpod.io/#https://github.com/svdarren/jupyter-template/pull/29"><img src="https://gitpod.io/api/apps/github/pbs/github.com/svdarren/jupyter-template.git/b7651b82d8aee358ccdd5b62b13ac715319191ec.svg" /></a>

